### PR TITLE
add siddii.scriptmonkey.wiki submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "scriptmonkey.wiki"]
 	path = scriptmonkey.wiki
 	url = https://github.com/vsch/scriptmonkey.wiki.git
+[submodule "siddii.scriptmonkey.wiki"]
+	path = siddii.scriptmonkey.wiki
+	url = https://github.com/siddii/scriptmonkey.wiki.git


### PR DESCRIPTION
Trying to see if wiki's will sync between forks. Yes, but wiki's are individual sub-modules by repository so need to keep both vsch/ and siddii/ versions. I want to have a forked version and sync with diff locally so I  don't have to worry about making inadvertent changes to siddii/scriptmonkey.wiki.